### PR TITLE
Add Claimscope SWE-bench bundle validation tooling

### DIFF
--- a/.github/workflows/claimscope-verify.yml
+++ b/.github/workflows/claimscope-verify.yml
@@ -1,0 +1,163 @@
+name: Claimscope SWE-bench Verification
+
+on:
+  pull_request:
+    paths:
+      - 'bundles/**'
+      - 'schemas/**'
+      - 'tools/claimscope_bundle_validate.py'
+      - '.github/workflows/claimscope-verify.yml'
+
+jobs:
+  swebench-verify:
+    name: Validate bundles and run SWE-bench harness
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install Python dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install swebench==3.0.17 jsonschema PyYAML ruff mypy
+
+      - name: Install gitleaks
+        run: |
+          curl -sSfL https://raw.githubusercontent.com/gitleaks/gitleaks/master/install.sh | bash -s -- -b /usr/local/bin
+
+      - name: Validate prediction bundles
+        id: validate
+        run: |
+          set -euo pipefail
+          BASE_REF="${{ github.base_ref }}"
+          if [[ -z "$BASE_REF" ]]; then
+            BASE_REF="${{ github.event.repository.default_branch }}"
+          fi
+          git fetch origin "$BASE_REF":"refs/remotes/origin/${BASE_REF}"
+          mapfile -t CHANGED < <(git diff --name-only "origin/${BASE_REF}...HEAD" -- 'bundles/**/MANIFEST.yaml' 'bundles/**/*.jsonl')
+          if [[ ${#CHANGED[@]} -eq 0 ]]; then
+            echo "no_bundles=1" >> "$GITHUB_OUTPUT"
+            echo "No bundle changes detected"
+            exit 0
+          fi
+          declare -A SEEN
+          for path in "${CHANGED[@]}"; do
+            dir=$(dirname "$path")
+            SEEN["$dir"]=1
+          done
+          for bundle in "${!SEEN[@]}"; do
+            echo "Validating $bundle"
+            python tools/claimscope_bundle_validate.py "$bundle"
+          done
+          printf '%s\n' "${CHANGED[@]}" > changed_files.txt
+          echo "changed_manifest_list=$(pwd)/changed_files.txt" >> "$GITHUB_OUTPUT"
+          echo "no_bundles=0" >> "$GITHUB_OUTPUT"
+
+      - name: Run SWE-bench harness on changed instances
+        if: steps.validate.outputs.no_bundles == '0'
+        env:
+          GITHUB_RUN_ID: ${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          BASE_REF="${{ github.base_ref }}"
+          if [[ -z "$BASE_REF" ]]; then
+            BASE_REF="${{ github.event.repository.default_branch }}"
+          fi
+          mapfile -t PREDICTIONS < <(git diff --name-only "origin/${BASE_REF}...HEAD" -- 'bundles/**/*.jsonl')
+          if [[ ${#PREDICTIONS[@]} -eq 0 ]]; then
+            echo "No prediction files modified"
+            exit 0
+          fi
+          printf '%s\n' "${PREDICTIONS[@]}" > predictions.txt
+          export BASE_REF_REF="origin/${BASE_REF}"
+          python <<'PY'
+import json
+import os
+import subprocess
+from pathlib import Path
+
+import yaml
+
+base_ref = os.environ.get('BASE_REF_REF')
+if not base_ref:
+    raise SystemExit('BASE_REF_REF not provided')
+
+predictions_file = Path('predictions.txt')
+prediction_paths = [line.strip() for line in predictions_file.read_text(encoding='utf-8').splitlines() if line.strip()]
+if not prediction_paths:
+    raise SystemExit('No prediction file paths provided')
+
+
+def load_entries_from_ref(path: str) -> dict[str, dict]:
+    result = subprocess.run(
+        ['git', 'show', f'{base_ref}:{path}'],
+        check=False,
+        text=True,
+        capture_output=True,
+    )
+    if result.returncode != 0:
+        return {}
+    entries: dict[str, dict] = {}
+    for line in result.stdout.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        obj = json.loads(line)
+        entries[obj['instance_id']] = obj
+    return entries
+
+
+for rel_path in prediction_paths:
+    predictions_path = Path(rel_path)
+    manifest_path = predictions_path.with_name('MANIFEST.yaml')
+    if not manifest_path.exists():
+        raise SystemExit(f'Manifest not found for {predictions_path}')
+
+    manifest = yaml.safe_load(manifest_path.read_text(encoding='utf-8')) or {}
+    dataset = manifest.get('dataset', 'princeton-nlp/SWE-bench_Verified')
+    split = manifest.get('split', 'test')
+
+    current_entries: list[dict] = []
+    with predictions_path.open('r', encoding='utf-8') as handle:
+        for line in handle:
+            line = line.strip()
+            if not line:
+                continue
+            current_entries.append(json.loads(line))
+
+    previous_entries = load_entries_from_ref(rel_path)
+    changed_ids = [
+        entry['instance_id']
+        for entry in current_entries
+        if previous_entries.get(entry['instance_id']) != entry
+    ]
+
+    if not changed_ids:
+        continue
+
+    cmd = [
+        'python',
+        'packages/harness/swebench/cli.py',
+        '--predictions',
+        str(predictions_path),
+        '--dataset-name',
+        dataset,
+        '--split',
+        split,
+        '--run-id',
+        f"github_{os.environ.get('GITHUB_RUN_ID')}_{predictions_path.stem}",
+    ]
+    for instance_id in changed_ids:
+        cmd.extend(['--instance-id', instance_id])
+
+    print('Running harness:', ' '.join(cmd))
+    subprocess.run(cmd, check=True)
+PY

--- a/bundles/example/MANIFEST.yaml
+++ b/bundles/example/MANIFEST.yaml
@@ -1,0 +1,7 @@
+version: claimscope.swe.v1
+dataset: princeton-nlp/SWE-bench_Lite
+split: test
+predictions: predictions.claimscope.v1.jsonl
+metadata:
+  title: Example Claimscope Bundle
+  description: Minimal example predictions for documentation and tests.

--- a/bundles/example/predictions.claimscope.v1.jsonl
+++ b/bundles/example/predictions.claimscope.v1.jsonl
@@ -1,0 +1,1 @@
+{"instance_id": "django__django-13069", "model_name_or_path": "claimscope/example-model", "model_patch": "diff --git a/example.py b/example.py\nindex 1111111..2222222 100644\n--- a/example.py\n+++ b/example.py\n@@ -1,3 +1,7 @@\n-print(\"hello\")\n+def greet() -> None:\n+    \"\"\"Print a friendly greeting.\"\"\"\n+    print(\"hello world\")\n+\n+greet()\n"}

--- a/schemas/claimscope.swe.v1.json
+++ b/schemas/claimscope.swe.v1.json
@@ -1,0 +1,46 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://claimscope.ai/schemas/claimscope.swe.v1.json",
+  "title": "Claimscope SWE-bench Prediction",
+  "description": "Schema for a single SWE-bench prediction entry consumed by Claimscope tooling.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "instance_id",
+    "model_name_or_path",
+    "model_patch"
+  ],
+  "properties": {
+    "instance_id": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Unique SWE-bench instance identifier (e.g., `tensorflow__tensorflow-15946`)."
+    },
+    "model_name_or_path": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Model identifier or checkpoint path that produced the prediction."
+    },
+    "model_patch": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Unified diff patch proposed by the model."
+    },
+    "confidence": {
+      "type": "number",
+      "minimum": 0.0,
+      "maximum": 1.0,
+      "description": "Optional self-reported confidence score between 0 and 1."
+    },
+    "metadata": {
+      "type": "object",
+      "description": "Arbitrary metadata captured during inference.",
+      "additionalProperties": true
+    },
+    "submission_timestamp": {
+      "type": "string",
+      "format": "date-time",
+      "description": "RFC3339 timestamp when the prediction was generated."
+    }
+  }
+}

--- a/tools/claimscope_bundle_validate.py
+++ b/tools/claimscope_bundle_validate.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python3
+"""Validate Claimscope SWE-bench prediction bundles."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Iterable, List
+
+try:
+    import yaml
+except ModuleNotFoundError as exc:  # pragma: no cover - defensive
+    raise SystemExit("PyYAML is required to run claimscope_bundle_validate") from exc
+
+try:
+    from jsonschema import Draft202012Validator
+except ModuleNotFoundError as exc:  # pragma: no cover - defensive
+    raise SystemExit("jsonschema is required to run claimscope_bundle_validate") from exc
+
+
+REQUIRED_MANIFEST_FIELDS = {"version", "dataset", "split", "predictions"}
+
+
+def _load_schema(schema_path: Path) -> Draft202012Validator:
+    data = json.loads(schema_path.read_text(encoding="utf-8"))
+    return Draft202012Validator(data)
+
+
+def _load_manifest(path: Path) -> dict:
+    data = yaml.safe_load(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise ValueError("MANIFEST.yaml must decode to a mapping")
+    missing = REQUIRED_MANIFEST_FIELDS - data.keys()
+    if missing:
+        raise ValueError(f"MANIFEST.yaml missing required fields: {sorted(missing)}")
+    return data
+
+
+def _iter_predictions(predictions_path: Path) -> Iterable[dict]:
+    for line_number, raw_line in enumerate(predictions_path.read_text(encoding="utf-8").splitlines(), start=1):
+        raw_line = raw_line.strip()
+        if not raw_line:
+            continue
+        try:
+            item = json.loads(raw_line)
+        except json.JSONDecodeError as exc:
+            raise ValueError(f"Invalid JSON on line {line_number}: {exc}") from exc
+        if not isinstance(item, dict):
+            raise ValueError(f"Prediction on line {line_number} must be an object")
+        yield item
+
+
+def _run(cmd: List[str], *, cwd: Path | None = None, input_text: str | None = None) -> subprocess.CompletedProcess[str]:
+    result = subprocess.run(
+        cmd,
+        cwd=str(cwd) if cwd else None,
+        input=input_text,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    return result
+
+
+def _check_patch(patch: str, repo: Path) -> None:
+    process = _run(["git", "apply", "--check", "--3way"], cwd=repo, input_text=patch)
+    if process.returncode != 0:
+        message = process.stderr.strip() or process.stdout.strip() or "<no output>"
+        raise RuntimeError(f"git apply --check --3way failed:\n{message}")
+
+
+def _run_optional(cmd: List[str], description: str, *, cwd: Path | None = None) -> None:
+    process = _run(cmd, cwd=cwd)
+    if process.returncode != 0:
+        raise RuntimeError(
+            f"{description} failed (exit {process.returncode}):\n{process.stdout}{process.stderr}"
+        )
+
+
+def validate_bundle(bundle_dir: Path, schema_path: Path, repo_path: Path | None) -> None:
+    manifest_path = bundle_dir / "MANIFEST.yaml"
+    if not manifest_path.exists():
+        raise FileNotFoundError(f"Missing MANIFEST.yaml in {bundle_dir}")
+
+    manifest = _load_manifest(manifest_path)
+
+    predictions_path = bundle_dir / manifest["predictions"]
+    if not predictions_path.exists():
+        raise FileNotFoundError(f"Predictions file not found: {predictions_path}")
+
+    validator = _load_schema(schema_path)
+
+    for prediction in _iter_predictions(predictions_path):
+        errors = sorted(validator.iter_errors(prediction), key=lambda e: e.path)
+        if errors:
+            details = "; ".join(f"{'/'.join(map(str, err.path)) or '<root>'}: {err.message}" for err in errors)
+            raise ValueError(f"Prediction failed schema validation: {details}")
+        if repo_path is not None:
+            try:
+                _check_patch(prediction["model_patch"], repo_path)
+            except KeyError as exc:
+                raise ValueError("Prediction missing required field 'model_patch'") from exc
+
+    script_path = Path(__file__)
+
+    _run_optional([sys.executable, "-m", "py_compile", str(script_path)], "py_compile")
+
+    try:
+        _run_optional(["ruff", "check", str(script_path)], "ruff lint")
+    except FileNotFoundError:
+        print("ruff not installed; skipping lint", file=sys.stderr)
+
+    try:
+        _run_optional(["mypy", "--ignore-missing-imports", str(script_path)], "mypy type-check")
+    except FileNotFoundError:
+        print("mypy not installed; skipping type-check", file=sys.stderr)
+
+    try:
+        _run_optional([
+            "gitleaks",
+            "detect",
+            "--no-banner",
+            "--redact",
+            "--source",
+            str(bundle_dir),
+        ], "gitleaks scan")
+    except FileNotFoundError:
+        print("gitleaks not installed; skipping secret scan", file=sys.stderr)
+
+
+def parse_args(argv: List[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Validate Claimscope SWE-bench prediction bundle")
+    parser.add_argument("bundle", type=Path, help="Path to bundle directory")
+    parser.add_argument(
+        "--schema",
+        type=Path,
+        default=Path(__file__).resolve().parents[1] / "schemas" / "claimscope.swe.v1.json",
+        help="Path to Claimscope SWE-bench schema",
+    )
+    parser.add_argument("--repo", type=Path, default=None, help="Optional git repository for git apply --check")
+    return parser.parse_args(argv)
+
+
+def main(argv: List[str] | None = None) -> int:
+    args = parse_args(argv or sys.argv[1:])
+    try:
+        validate_bundle(args.bundle, args.schema, args.repo)
+    except Exception as exc:  # pragma: no cover - CLI entry point
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add a JSON schema describing Claimscope SWE-bench prediction entries
- provide a bundle validation helper that checks manifests, schemas, and static analysis tools
- wire up CI to validate bundles and execute the SWE-bench harness for changed predictions, plus seed an example bundle

## Testing
- python tools/claimscope_bundle_validate.py bundles/example

------
https://chatgpt.com/codex/tasks/task_e_68e04c8b0414832cb56f18531e00408f